### PR TITLE
Add tweet retrieve API

### DIFF
--- a/comments/api/views.py
+++ b/comments/api/views.py
@@ -4,6 +4,7 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 from comments.models import Comment
 from tweets.models import Tweet
 from tweets.api.serializers import TweetSerializer
+from utils.decorators import required_params
 from comments.api.permissions import IsObjectOwner
 from comments.api.serializers import (
     CommentSerializerForCreate,
@@ -27,6 +28,7 @@ class CommentViewSet(viewsets.GenericViewSet):
             return [IsAuthenticated(), IsObjectOwner()]
         return [AllowAny()]
 
+    @required_params(params=['tweet_id'])
     def list(self, request, *args, **kwargs):
         if 'tweet_id' not in request.query_params:
             return Response({

--- a/tweets/api/serializers.py
+++ b/tweets/api/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 from tweets.models import Tweet
+from comments.api.serializers import CommentSerializer
 from accounts.api.serializers import UserSerializerForTweet
 
 
@@ -23,3 +24,11 @@ class TweetSerializerForCreate(serializers.ModelSerializer):
         content = validated_data['content']
         tweet = Tweet.objects.create(user=user, content=content)
         return tweet
+
+
+class TweetSerializerWithComments(TweetSerializer):
+    comments = CommentSerializer(source='comment_set', many=True)
+
+    class Meta:
+        model = Tweet
+        fields = ('id', 'user', 'created_at', 'content', 'comments')

--- a/tweets/api/tests.py
+++ b/tweets/api/tests.py
@@ -5,7 +5,7 @@ from tweets.models import Tweet
 
 TWEET_LIST_API = '/api/tweets/'
 TWEET_CREATE_API = '/api/tweets/'
-
+TWEET_RETRIEVE_API = '/api/tweets/{}/'
 
 class TweetApiTests(TestCase):
 
@@ -69,3 +69,22 @@ class TweetApiTests(TestCase):
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.data['user']['id'], self.user1.id)
         self.assertEqual(Tweet.objects.count(), tweets_count + 1)
+
+    def test_retrieve(self):
+        # tweet with id=-1 does not exist
+        url = TWEET_RETRIEVE_API.format(-1)
+        response = self.anonymous_client.get(url)
+        self.assertEqual(response.status_code, 404)
+
+        # Test if comments are retrieved together with tweet
+        tweet = self.create_tweet(self.user1)
+        url = TWEET_RETRIEVE_API.format(tweet.id)
+        response = self.anonymous_client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['comments']), 0)
+
+        self.create_comment(self.user2, tweet, 'nice')
+        self.create_comment(self.user1, tweet, 'cool')
+        self.create_comment(self.user1, self.create_tweet(self.user2), '...')
+        response = self.anonymous_client.get(url)
+        self.assertEqual(len(response.data['comments']), 2)

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -1,0 +1,31 @@
+from rest_framework.response import Response
+from rest_framework import status
+from functools import wraps
+
+
+def required_params(request_attr='query_params', params=None):
+    if params is None:
+        params = []
+
+    def decorator(view_func):
+        """
+        decorator 函数通过 wraps 来将 view_func 里的参数解析出来传递给 _wrapped_view
+        这里的 instance 参数其实就是在 view_func 里的 self
+        """
+        @wraps(view_func)
+        def _wrapped_view(instance, request, *args, **kwargs):
+            data = getattr(request, request_attr)
+            missing_params = [
+                param
+                for param in params
+                if param not in data
+            ]
+            if missing_params:
+                params_str = ','.join(missing_params)
+                return Response({
+                    'message': f'missing {params_str} in request.',
+                    'success': False,
+                }, status=status.HTTP_400_BAD_REQUEST)
+            return view_func(instance, request, *args, **kwargs)
+        return _wrapped_view
+    return decorator


### PR DESCRIPTION
1. Add decorator for list method and other methods that require query parameter check first
2. Add retrieve method in tweets
3. Add tweet serializer that shows tweet and associated comments together.
4. Test retrieve API